### PR TITLE
Update to 0.16 on aarch64, arm64, and win32

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,7 @@ source:
 
 build:
   skip: true  # [py<36]
-  # skipping win-32 because it's not clear that it is actually supported
-  # https://github.com/MagicStack/immutables/issues/50
-  skip: true  # [win32]
-  number: 0
+  number: 1
   script: python -m pip install . --no-deps --ignore-installed
 
 requirements:
@@ -36,7 +33,7 @@ test:
   # Which is strange given the tests directory is being copied.
   # Dropping running tests for now until someone takes the time to look into it.
   # requires:
-  #   - flake8 =3.8.4
+  #   - flake8 >=3.8.4
   #   - pycodestyle >=2.6.*
   #   - mypy >=0.910
   #   - pytest >=6.2.4
@@ -54,7 +51,7 @@ test:
 about:
   home: https://github.com/MagicStack/immutables
   license: Apache-2.0
-  license_family: APACHE
+  license_family: Apache
   license_file: LICENSE
   summary: Immutable Collections
   description: An immutable mapping type for Python.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,8 @@ test:
 
 about:
   home: https://github.com/MagicStack/immutables
-  license: Apache-2.0
+  # See https://github.com/MagicStack/immutables/blob/v0.16/LICENSE
+  license: Apache-2.0 AND MIT
   license_family: Apache
   license_file: LICENSE
   summary: Immutable Collections


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/MagicStack/immutables/issues
Github releases:  https://github.com/MagicStack/immutables/releases
Upstream license:  License file:  https://github.com/MagicStack/immutables/blob/master/LICENSE
Upstream setup file: https://github.com/MagicStack/immutables/blob/v0.16/setup.py
Upstream pyproject file: https://github.com/MagicStack/immutables/blob/v0.16/pyproject.toml

The package immutables is mentioned inside the packages:
contextvars |

Actions:
1. Remove `skip: true  # [win32]` because the issue with this platform was fixed https://github.com/MagicStack/immutables/pull/70
2. Bump build number to `1`.

Result:
- all-succeeded