### PR TITLE
immutables 0.21 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<38]
   number: 0
-  script: python -m pip install . --no-deps --ignore-installed
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b55ffaf0449790242feb4c56ab799ea7af92801a0a43f9e2f4f8af2ab24dfc4a
 
 build:
-  skip: true  # [py<36]
+  skip: true  # [py<38]
   number: 0
   script: python -m pip install . --no-deps --ignore-installed
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: b55ffaf0449790242feb4c56ab799ea7af92801a0a43f9e2f4f8af2ab24dfc4a
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ stdlib('c')}}
+    - {{ stdlib('c') }}
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: b55ffaf0449790242feb4c56ab799ea7af92801a0a43f9e2f4f8af2ab24dfc4a
+  patches:
+    - patches/python_39_types_capitalization.patch  # [py>=39]
 
 build:
   skip: true  # [py<38]
@@ -37,7 +39,7 @@ test:
     - mypy >=1.4,<2
   commands:
     - pip check
-    - pytest -vv --deselect=tests/test_mypy.py::ImmuMypyTest::check-immu.test::testMypyImmu tests
+    - pytest -vv tests
 
 about:
   home: https://github.com/MagicStack/immutables

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c')}}
   host:
     - python
     - pip
@@ -24,7 +25,6 @@ requirements:
     - wheel
   run:
     - python
-    - typing-extensions >=3.7.4.3  # [py<38]
 
 test:
   # As per Maintainer,Since immutables introduced mypy testing, the mypy plugin fails with this error:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,25 +27,17 @@ requirements:
     - python
 
 test:
-  # As per Maintainer,Since immutables introduced mypy testing, the mypy plugin fails with this error:
-  #   FileNotFoundError: [Errno 2] No such file or directory: '$SRC_DIR/tests/test-data/check-immu.test'
-  # Which is strange given the tests directory is being copied.
-  # Dropping running tests for now until someone takes the time to look into it.
-  # requires:
-  #   - flake8 >=3.8.4
-  #   - pycodestyle >=2.6.*
-  #   - mypy >=0.910
-  #   - pytest >=6.2.4
-  # source_files:
-  #   - tests
-  
+  source_files:
+    - tests
   imports:
     - immutables
   requires:
     - pip
+    - pytest >=7.4,<8
+    - mypy >=1.4,<2
   commands:
-  #  - pytest tests
     - pip check
+    - pytest -vv --deselect=tests/test_mypy.py::ImmuMypyTest::check-immu.test::testMypyImmu tests
 
 about:
   home: https://github.com/MagicStack/immutables

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "immutables" %}
-{% set version = "0.16" %}
+{% set version = "0.21" %}
 
 package:
   name: {{ name|lower }}
@@ -8,11 +8,11 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d67e86859598eed0d926562da33325dac7767b7b1eff84e232c22abea19f4360
+  sha256: b55ffaf0449790242feb4c56ab799ea7af92801a0a43f9e2f4f8af2ab24dfc4a
 
 build:
   skip: true  # [py<36]
-  number: 1
+  number: 0
   script: python -m pip install . --no-deps --ignore-installed
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: b55ffaf0449790242feb4c56ab799ea7af92801a0a43f9e2f4f8af2ab24dfc4a
   patches:
     - patches/python_39_types_capitalization.patch  # [py>=39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,14 +43,13 @@ test:
 
 about:
   home: https://github.com/MagicStack/immutables
-  # See https://github.com/MagicStack/immutables/blob/v0.16/LICENSE
-  license: Apache-2.0 AND MIT
+  license: Apache-2.0 AND 0BSD
   license_family: Apache
   license_file: LICENSE
   summary: Immutable Collections
-  description: An immutable mapping type for Python.
+  description: A high-performance immutable mapping type for Python.
   dev_url: https://github.com/MagicStack/immutables
-  doc_url: https://github.com/MagicStack/immutables/blob/master/README.rst
+  doc_url: https://github.com/MagicStack/immutables
 
 extra:
   recipe-maintainers:

--- a/recipe/patches/python_39_types_capitalization.patch
+++ b/recipe/patches/python_39_types_capitalization.patch
@@ -1,0 +1,28 @@
+diff --git a/tests/test-data/check-immu.test b/tests/test-data/check-immu.test
+index 2ee32f1..bbbfe11 100644
+--- a/tests/test-data/check-immu.test
++++ b/tests/test-data/check-immu.test
+@@ -45,19 +45,19 @@ def update() -> None:
+ 
+     m_int__str.update({1: '2'})
+     m_int__str.update({1: '2'}, three='4')  # E: Unexpected keyword argument "three" for "update" of "Map"
+-    m_int__str.update({1: 2})  # E: Argument 1 to "update" of "Map" has incompatible type "Dict[int, int]"; expected "Union[IterableItems[int, str], Iterable[Tuple[int, str]]]"
++    m_int__str.update({1: 2})  # E: Argument 1 to "update" of "Map" has incompatible type "dict[int, int]"; expected "Union[IterableItems[int, str], Iterable[tuple[int, str]]]"
+ 
+     m_str__str.update({'1': '2'})
+     m_str__str.update({'1': '2'}, three='4')
+-    m_str__str.update({'1': 2})  # E: Argument 1 to "update" of "Map" has incompatible type "Dict[str, int]"; expected "Union[IterableItems[str, str], Iterable[Tuple[str, str]]]"
++    m_str__str.update({'1': 2})  # E: Argument 1 to "update" of "Map" has incompatible type "dict[str, int]"; expected "Union[IterableItems[str, str], Iterable[tuple[str, str]]]"
+ 
+     m_int_str__str.update(cast(Dict[Union[int, str], str], {1: '2', '3': '4'}))
+     m_int_str__str.update({1: '2'}, three='4')
+-    m_int_str__str.update({'1': 2})  # E: Argument 1 to "update" of "Map" has incompatible type "Dict[str, int]"; expected "Union[IterableItems[Union[int, str], str], Iterable[Tuple[Union[int, str], str]]]"
++    m_int_str__str.update({'1': 2})  # E: Argument 1 to "update" of "Map" has incompatible type "dict[str, int]"; expected "Union[IterableItems[Union[int, str], str], Iterable[tuple[Union[int, str], str]]]"
+ 
+     m_str__int_str.update({'1': 2, '2': 3})
+     m_str__int_str.update({'1': 2, '2': 3}, four='5')
+-    m_str__int_str.update({1: 2})  # E: Argument 1 to "update" of "Map" has incompatible type "Dict[int, int]"; expected "Union[IterableItems[str, Union[int, str]], Iterable[Tuple[str, Union[int, str]]]]"
++    m_str__int_str.update({1: 2})  # E: Argument 1 to "update" of "Map" has incompatible type "dict[int, int]"; expected "Union[IterableItems[str, Union[int, str]], Iterable[tuple[str, Union[int, str]]]]"
+ 
+ def mutate() -> None:
+     m = Map[str, str]()


### PR DESCRIPTION
immutables 0.21 

**Destination channel:** Defaults

### Links

- [PKG-9414]
- dev_url:        https://github.com/MagicStack/immutables/tree/v0.21
- conda_forge:    https://github.com/conda-forge/immutables-feedstock
- pypi:           https://pypi.org/project/immutables/0.21
- pypi inspector: https://inspector.pypi.io/project/immutables/0.21

### Explanation of changes:

- new version number


[PKG-9414]: https://anaconda.atlassian.net/browse/PKG-9414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ